### PR TITLE
Support dynamic insertion of SQL identifiers and names.

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -4,7 +4,7 @@
 ;; pkg info
 
 (define collection "sql")
-(define version "1.1")
+(define version "1.2")
 
 (define deps
   '(["base" #:version "6.3"]

--- a/private/ast.rkt
+++ b/private/ast.rkt
@@ -346,6 +346,7 @@
 ;; A Name is one of
 ;; - Ident                -- unqualified name
 ;; - (qname Name Ident)   -- qualified name
+;; * (list 'unquote Syntax)
 (struct qname (qual id) #:prefab)
 
 (define (name-ast? x)
@@ -355,6 +356,7 @@
 ;; An Ident is one of
 ;; - (id:normal Symbol)   -- to be transmitted unquoted
 ;; - (id:literal String)  -- to be quoted when emitted
+;; * (list 'unquote Syntax)
 (struct id:normal (s) #:prefab)
 (struct id:quoted (s) #:prefab)
 

--- a/sql.scrbl
+++ b/sql.scrbl
@@ -848,6 +848,7 @@ order. If the first form of @svar[select-statement] is used (that is,
 with the initial @svar[select-item]s), then the @racket[#:values]
 clause may not also be used.
 
+@history[#:changed "1.2" @elem{Added @svar[distinct-clause]}]
 
 @bold{Insert}
 
@@ -998,6 +999,11 @@ computed from an untrusted source. Use placeholders or
 @racket[unquote] parameters instead; see @secref["unquote"].
 
 @racketgrammar*[
+[ident ....
+       (@#,lit{Ident:AST} (@#,lit{unquote} ast-racket-expr))]
+
+[name ....
+       (@#,lit{Name:AST} (@#,lit{unquote} ast-racket-expr))]
 
 [scalar-expr ....
              (@#,lit{ScalarExpr:AST} (@#,lit{unquote} ast-racket-expr))
@@ -1012,12 +1018,16 @@ computed from an untrusted source. Use placeholders or
            (@#,lit{TableRef:INJECT} (@#,lit{unquote} string-racket-expr))]
 ]
 
+@history[#:changed "1.2" @elem{Added @lit{Ident:AST} and @lit{Name:AST}}]
+
 
 @defproc[(make-ident-ast [s (or/c symbol? string?)])
          ident-ast?]{
 
 Produces an identifier AST from @racket[s] by applying the rules in
 @secref["names"] to the term @racket[`(Ident: ,s)].
+
+@history[#:added "1.2"]
 
 @examples[#:eval the-eval
 (sql-ast->string (make-ident-ast 'MyTable))
@@ -1042,6 +1052,8 @@ of the @svar[name] nonterminal (see @secref["names"]).}
 the components are joined.}
 ]
 
+@history[#:added "1.2"]
+
 @examples[#:eval the-eval
 (sql-ast->string (make-name-ast 'x))
 (sql-ast->string (make-name-ast 'x.y.z))
@@ -1055,6 +1067,8 @@ the components are joined.}
 Produces a scalar expression AST representing the Racket value @racket[value].
 
 Equivalent to @racket[(scalar-expr-qq (unquote value))].
+
+@history[#:added "1.2"]
 }
 
 @(close-eval db-eval)


### PR DESCRIPTION
This commit extends the grammar for `ident` and `name`
to include `(Ident:AST (unquote ast-racket-expr))` and
`(Name:AST (unquote ast-racket-expr))`, respectively,
where the inserted AST value must satisfy the corresponding
(pre-existing) predicate, i.e. `ident-ast?` or `name-ast?`.

The motivation is to make it possible to abstract over
the table name in `INSERT`, `UPDATE`, `DELETE`, and `CREATE TABLE`
statements, though the additions should be more generally useful.
For example, the following function now works as expected:
```racket
(define (delete* table)
  (delete #:from (Name:AST ,table)))

(delete* (ident-qq myTable))
```
Writing such a function was not possible before, as the term following
`#:from` is restricted to be a `table-name`, not an arbitary `table-ref`.

There is an oddity in the interaction between the `name` nonterminal
and the `table-ref` nonterminal due to the internal representation.
Given an `ident` AST value:
```racket
(define id
  (ident-qq myTable))
```
the `id` value will not satisfy `table-ref-ast?`, and attempting
to use it as a `table-ref` (e.g. `(select col #:from (TableRef:AST ,id))`)
will raise an exception.

A workaround is needed to make the library wrap the value in
a `table-ref:name` struct:
```racket
(define ref
  (table-ref-qq (Name:AST ,id)))

(table-ref-ast? ref)

(select col #:from (TableRef:AST ,ref))
```

It would seem desirable to investigate adjusting the internal
representations to make values that satisfy `name-ast?`
also satisfy `table-ref-ast?`.
Alternatively, the workaround could be documented.

Incremented package version to "1.1.1".