### PR TITLE
Add make-values*-table-expr-ast function

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -4,7 +4,7 @@
 ;; pkg info
 
 (define collection "sql")
-(define version "1.2")
+(define version "1.3")
 
 (define deps
   '(["base" #:version "6.3"]

--- a/main.rkt
+++ b/main.rkt
@@ -1,38 +1,40 @@
 #lang racket/base
 (require racket/contract/base
+         racket/contract/combinator
          "private/syntax.rkt"
          "private/ast.rkt"
          "private/emit.rkt"
          "private/dynamic.rkt")
 
-(provide ;; from private/ast.rkt
-         statement-ast?
-         ddl-ast?
-         table-ref-ast?
-         table-expr-ast?
-         scalar-expr-ast?
-         ident-ast?
-         name-ast?
+(provide
+ ;; from private/ast.rkt
+ statement-ast?
+ ddl-ast?
+ table-ref-ast?
+ table-expr-ast?
+ scalar-expr-ast?
+ ident-ast?
+ name-ast?
 
-         ;; from private/syntax.rkt
-         name-qq
-         ident-qq
-         table-ref-qq
-         table-expr-qq
-         scalar-expr-qq
-         statement-qq
-         select-qq
-         ddl-qq
+ ;; from private/syntax.rkt
+ name-qq
+ ident-qq
+ table-ref-qq
+ table-expr-qq
+ scalar-expr-qq
+ statement-qq
+ select-qq
+ ddl-qq
 
-         sql
-         select
-         insert
-         update
-         delete
-         create-table
-         create-view
+ sql
+ select
+ insert
+ update
+ delete
+ create-table
+ create-view
 
-         sql-statement?)
+ sql-statement?)
 
 (provide
  (contract-out
@@ -50,4 +52,29 @@
   [make-name-ast
    (-> (flat-rec-contract C symbol? name-ast? (listof C)) name-ast?)]
   [value->scalar-expr-ast
-   (-> any/c scalar-expr-ast?)]))
+   (-> any/c scalar-expr-ast?)]
+  [make-values*-table-expr-ast
+   (-> (and/c (listof (listof scalar-expr-ast?))
+              ;; rows-same-length/c must come second
+              rows-same-length/c)
+       table-expr-ast?)]))
+
+;; rows-same-length/c:
+;;   contract version of check-same-length from "private/ast.rkt".
+;; Assumes that value to be checked would satisfy (listof (listof any/c)),
+;;   so use this as the second case in an and/c contract.
+(define rows-same-length/c
+  (flat-contract-with-explanation
+   #:name 'rows-same-length/c
+   (λ (l-rows)
+     (or (check-same-length l-rows)
+         (λ (blame)
+           (raise-blame-error
+            blame l-rows
+            '("all rows must be the same length"
+              given: "~e"
+              "\n  " given " lengths: ~e")
+            l-rows
+            (map length l-rows)))))))
+
+

--- a/private/ast.rkt
+++ b/private/ast.rkt
@@ -194,6 +194,22 @@
       (table-expr:values? x)
       (table-expr:select? x)))
 
+;; check-same-length : (Listof (Listof Any)) -> Boolean
+;; Returns #t IFF all inner lists are the same length.
+;; This is needed as a check for table-expr:values
+;; at both compile-time and runtime
+;; (i.e. for syntax like (values* (1 2 3) (4 5 6))
+;; in the TableExpr syntax class
+;; and the make-values*-table-expr-ast function).
+(define check-same-length
+  (match-lambda
+    ['() #t]
+    [(cons this more)
+     (define len0
+       (length this))
+     (for/and ([this (in-list more)])
+       (= len0 (length this)))]))
+
 ;; ----------------------------------------
 ;; Scalar Expressions
 
@@ -242,7 +258,8 @@
       (scalar:in-values? x)
       (scalar:some/all? x)
       (scalar:placeholder? x)
-      (scalar:inject? x)))
+      (scalar:inject? x)
+      (scalar:unquote? x)))
 
 ;; An Arity is one of
 ;; - Nat

--- a/private/dynamic.rkt
+++ b/private/dynamic.rkt
@@ -20,3 +20,9 @@
 (define (value->scalar-expr-ast value)
   ;; note: equivalent to (scalar-expr-qq ,value)
   (scalar:unquote value))
+
+;; make-values*-table-expr-ast :
+;;   (listof (listof scalar-expr-ast?)) -> table-expr-ast?
+;; Invariant: inner lists must be the same length
+(define make-values*-table-expr-ast
+  table-expr:values)

--- a/private/parse.rkt
+++ b/private/parse.rkt
@@ -390,7 +390,10 @@
   (pattern (values ~! e:ScalarExpr ...)
            #:attr ast (table-expr:values (list ($ e.ast))))
   (pattern (values* ~! [e:ScalarExpr ...] ...)
-           #:attr ast (table-expr:values ($ e.ast)))
+           #:do [(define l-rows ($ e.ast))]
+           #:fail-unless (check-same-length l-rows)
+           "values*: all rows must be the same length"
+           #:attr ast (table-expr:values l-rows))
   (pattern (~and (select ~! . _) s:Select)
            ;; was just s:Select, but this gives better errors
            #:attr ast (table-expr:select ($ s.ast))))

--- a/test.rkt
+++ b/test.rkt
@@ -166,7 +166,8 @@
 
 (test-stmt-err*
  (select a$)
- (select * from T))
+ (select * from T)
+ (select * #:from (values* (1 2) ("single"))))
 
 
 ;; Bad error for: (select x #:from ,"foo") --- why?


### PR DESCRIPTION
This change makes it possible to construct INSERT statements
for dynamic numbers of rows, for example.

Other changes:
- The `TableExpr` syntax class raises a syntax error if the
  `values*` form is used with rows that are not all of the same length.
- Fixed the `scalar-expr-ast?` predicate to recognize values that satisfy
  `scalar:unquote?`.
  Before this change, `value->scalar-expr-ast` would break its own
  contract (e.g. with `(value->scalar-expr-ast "apples")`.

Closes https://github.com/rmculpepper/sql/issues/9