### PR TITLE
fix bug in `select` with `#:limit` but no `#:order-by`

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -4,7 +4,7 @@
 ;; pkg info
 
 (define collection "sql")
-(define version "1.4")
+(define version "1.5")
 
 (define deps
   '(["base" #:version "6.3"]

--- a/private/emit.rkt
+++ b/private/emit.rkt
@@ -204,7 +204,7 @@
     (define/public (emit-select-extension ext)
       (match ext
         [(select:extension order limit offset)
-         (J (if order
+         (J (if (pair? order)
                 (J " ORDER BY " (J-join (map emit-select-order order) ", "))
                 "")
             (if limit

--- a/test.rkt
+++ b/test.rkt
@@ -128,7 +128,8 @@
  [(inner-join t1 t2 #:natural) "t1 NATURAL INNER JOIN t2"]
  [(values 1 2 3) "VALUES (1, 2, 3)"]
  [(values* (1 2 3) (4 5 6)) "VALUES (1, 2, 3), (4, 5, 6)"]
- [(select y #:from ys) "SELECT y FROM ys"])
+ [(select y #:from ys) "SELECT y FROM ys"]
+ [(select y #:from ys #:limit 1) "SELECT y FROM ys LIMIT 1"])
 
 ;; ------------------------------------------------------------
 ;; Statements


### PR DESCRIPTION
Previously, a statement like `(select y #:from ys #:limit 1)` would emit `SELECT y FROM ys ORDER BY LIMIT 1`.