### PR TITLE
UNION uses a boolean flag to indicate ALL.

### DIFF
--- a/private/emit.rkt
+++ b/private/emit.rkt
@@ -391,9 +391,9 @@
            [(union) " UNION "]
            [(except) " EXCEPT "]
            [(intersect) " INTERSECT "])
-         (case opt
-           [(all) "ALL "]
-           [else ""])
+         (match opt
+           [#t "ALL "]
+           [#f ""])
          (match corr
            [`#f ""]
            [`#t "CORRESPONDING "]

--- a/test.rkt
+++ b/test.rkt
@@ -129,7 +129,9 @@
  [(values 1 2 3) "VALUES (1, 2, 3)"]
  [(values* (1 2 3) (4 5 6)) "VALUES (1, 2, 3), (4, 5, 6)"]
  [(select y #:from ys) "SELECT y FROM ys"]
- [(select y #:from ys #:limit 1) "SELECT y FROM ys LIMIT 1"])
+ [(select y #:from ys #:limit 1) "SELECT y FROM ys LIMIT 1"]
+ [(union (select x #:from xs) (select y #:from ys) #:all)
+  "SELECT x FROM xs UNION ALL SELECT y FROM ys"])
 
 ;; ------------------------------------------------------------
 ;; Statements


### PR DESCRIPTION
Fix a bug where `ALL` was not being emitted.

@rmculpepper I'm not entirely sure the original intent here; was there meant to be multiple options?