### PR TITLE
Relax :WithInner to allow for :TableExpr as well as :Statement

### DIFF
--- a/private/emit.rkt
+++ b/private/emit.rkt
@@ -137,7 +137,9 @@
          (J "WITH "
             (if rec? "RECURSIVE " "")
             (J-join (for/list ([h (in-list headers)] [rhs (in-list rhss)])
-                      (J (emit-with-header h) " AS (" (emit-statement rhs) ")"))
+                      (J (emit-with-header h) " AS (" (if (statement-ast? rhs)
+                                                          (emit-statement rhs)
+                                                          (emit-table-expr rhs)) ")"))
                     ", ")
             " "
             (emit-statement body))]))

--- a/private/parse.rkt
+++ b/private/parse.rkt
@@ -164,7 +164,7 @@
 (define-syntax-class WithInner
   #:attributes (ast) #:commit
   #:description #f
-  (pattern (_ rec:MaybeRec ([h:TableWColumns rhs:Statement] ...) body:Statement)
+  (pattern (_ rec:MaybeRec ([h:TableWColumns (~or rhs:TableExpr rhs:Statement)] ...) body:Statement)
            #:attr ast (statement:with ($ rec.ast) ($ h.ast) ($ rhs.ast) ($ body.ast))))
 
 (define-splicing-syntax-class MaybeRec

--- a/test.rkt
+++ b/test.rkt
@@ -162,7 +162,13 @@
          #:where (= b ?))
  (insert #:into T #:columns a b c #:from (select * #:from S #:where (= d ?)))
  (insert #:into T #:set [a 1] [b 2] [c 3])
- (update T #:set [a (+ a 1)] [b (- b 1)] #:where (< T.a 0)))
+ (update T #:set [a (+ a 1)] [b (- b 1)] #:where (< T.a 0))
+ (with #:recursive
+        ([(cnt x) (union
+                   (select 1)
+                   (select (+ 1 x)
+                           #:from cnt))])
+        (select x #:from cnt)))
 
 (define-syntax-rule (test-stmt-err* s ...)
   (begin (-test (check-exn #rx"" (lambda () (convert-syntax-error s)))) ...))


### PR DESCRIPTION
Both `sqllite3` and `postgres` support this form - it's quite a big change (changes the grammar).

This is a __speculative__ PR. Let me know if you think it's acceptable.

Fixes part of  #22.

[1] https://www.postgresql.org/docs/9.1/queries-with.html
[2] https://sqlite.org/lang_with.html